### PR TITLE
Bug fixes for matching service

### DIFF
--- a/backend/MatchingService/src/sockets/handlers.ts
+++ b/backend/MatchingService/src/sockets/handlers.ts
@@ -37,6 +37,7 @@ export const initializeSocketHandlers = (io: Server): void => {
     try {
       const userId = socket.data.userId;
       const username = socket.data.username;
+      socket.data.matchRequest = request;
       validateMatchRequest(request);
       socket.emit("match-request-accepted");
       logger.info(`Match requested for user ${username} (${userId})`, { request });
@@ -73,7 +74,7 @@ export const initializeSocketHandlers = (io: Server): void => {
       matchController.removeFromMatchingPool(userId, matchRequest);
     }
     matchController.removeConnection(userId);
-    socket.disconnect(true);
+    // socket.disconnect(true);
     logger.info(`User disconnected: user ${username} (${userId})`);
   };
 

--- a/backend/MatchingService/src/sockets/handlers.ts
+++ b/backend/MatchingService/src/sockets/handlers.ts
@@ -57,6 +57,7 @@ export const initializeSocketHandlers = (io: Server): void => {
     const matchRequest: MatchRequest | undefined = socket.data.matchRequest;
     if (matchRequest) {
       matchController.removeFromMatchingPool(userId, matchRequest);
+      matchController.removeTimeout(userId);
       socket.emit("match-cancelled");
       logger.info(`Match cancelled for user ${username} (${userId})`);
     } else {
@@ -72,10 +73,10 @@ export const initializeSocketHandlers = (io: Server): void => {
     const matchRequest: MatchRequest | undefined = socket.data.matchRequest;
     if (matchRequest) {
       matchController.removeFromMatchingPool(userId, matchRequest);
+      matchController.removeTimeout(userId);
     }
     matchController.removeConnection(userId);
     // socket.disconnect(true);
-    logger.info(`User disconnected: user ${username} (${userId})`);
   };
 
   io.on("connection", (socket: Socket) => {


### PR DESCRIPTION
- Fix matching service logging user undefined when matched (due to multiple tries to remove connected user)
- Fix user not removed from queue when they initiate a disconnect/match cancel
- Fix match timeout bug where timeout not being removed when client initiate disconnect/match cancel